### PR TITLE
Updates Labels for entities and adds Amazon option

### DIFF
--- a/dist/Home-Assistant-Mail-And-Packages-Custom-Card-editor.js
+++ b/dist/Home-Assistant-Mail-And-Packages-Custom-Card-editor.js
@@ -68,6 +68,10 @@ export class MailAndPackagesCardEditor extends LitElement {
         return this._config.usps_packages || "";
     }
 
+  get _amazon_packages() {
+    return this._config.amazon_packages || "";
+  }
+
     get _usps_mail() {
         return this._config.usps_mail || "";
     }
@@ -122,6 +126,7 @@ export class MailAndPackagesCardEditor extends LitElement {
           ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Mail Updated Sensor"
                   .hass="${this.hass}"
                   .value="${this._updated}"
                   .configValue=${"updated"}
@@ -151,6 +156,7 @@ export class MailAndPackagesCardEditor extends LitElement {
           ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Delivery Message Sensor"
                   .hass="${this.hass}"
                   .value="${this._deliveries_message}"
                   .configValue=${"deliveries_message"}
@@ -180,6 +186,7 @@ export class MailAndPackagesCardEditor extends LitElement {
          ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Packages Delivered Sensor"
                   .hass="${this.hass}"
                   .value="${this._packages_delivered}"
                   .configValue=${"packages_delivered"}
@@ -209,6 +216,7 @@ export class MailAndPackagesCardEditor extends LitElement {
           ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Packages In Transit Sensor"
                   .hass="${this.hass}"
                   .value="${this._packages_in_transit}"
                   .configValue=${"packages_in_transit"}
@@ -238,6 +246,7 @@ export class MailAndPackagesCardEditor extends LitElement {
               ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="FedEx Package Sensor"
                   .hass="${this.hass}"
                   .value="${this._fedex_packages}"
                   .configValue=${"fedex_packages"}
@@ -267,6 +276,7 @@ export class MailAndPackagesCardEditor extends LitElement {
               ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="UPS Package Sensor"
                   .hass="${this.hass}"
                   .value="${this._ups_packages}"
                   .configValue=${"ups_packages"}
@@ -296,6 +306,7 @@ export class MailAndPackagesCardEditor extends LitElement {
               ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="USPS Package Sensor"
                   .hass="${this.hass}"
                   .value="${this._usps_packages}"
                   .configValue=${"usps_packages"}
@@ -325,6 +336,37 @@ export class MailAndPackagesCardEditor extends LitElement {
               ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Amazon Package Sensor"
+                .hass="${this.hass}"
+                .value="${this._amazon_packages}"
+                .configValue=${"amazon_packages"}
+                domain-filter="sensor"
+                @change="${this._valueChanged}"
+                allow-custom-entity
+              ></ha-entity-picker>
+            `
+          : html`
+              <paper-dropdown-menu
+                label="Amazon Package Sensor"
+                @value-changed="${this._valueChanged}"
+                .configValue="${"amazon_packages"}"
+              >
+                <paper-listbox
+                  slot="dropdown-content"
+                  .selected="${entities.indexOf(this._amazon_packages)}"
+                >
+                  ${entities.map((amazon_packages) => {
+                    return html`
+                      <paper-item>${amazon_packages}</paper-item>
+                    `;
+                  })}
+                </paper-listbox>
+              </paper-dropdown-menu>
+            `}
+            ${customElements.get("ha-entity-picker")
+          ? html`
+              <ha-entity-picker
+                label="USPS Mail Sensor"
                   .hass="${this.hass}"
                   .value="${this._usps_mail}"
                   .configValue=${"usps_mail"}
@@ -372,6 +414,7 @@ export class MailAndPackagesCardEditor extends LitElement {
         ${customElements.get("ha-entity-picker")
             ? html`
                 <ha-entity-picker
+                label="Camera Entity"
                   .hass="${this.hass}"
                   .value="${this._camera_entity}"
                   .configValue=${"camera_entity"}

--- a/dist/Home-Assistant-Mail-And-Packages-Custom-Card.js
+++ b/dist/Home-Assistant-Mail-And-Packages-Custom-Card.js
@@ -100,12 +100,14 @@ class MailAndPackagesCard extends LitElement {
         const fedex_packages = this._config.fedex_packages ? this.hass.states[this._config.fedex_packages].state : false;
         const ups_packages = this._config.ups_packages ? this.hass.states[this._config.ups_packages].state : false;
         const usps_packages = this._config.usps_packages ? this.hass.states[this._config.usps_packages].state : false;
+        const amazon_packages = this._config.amazon_packages ? this.hass.states[this._config.amazon_packages].state : false;
         const usps_mail = this._config.usps_mail ? this.hass.states[this._config.usps_mail].state : false;
         
         const mail_icon = usps_mail > 0 ? 'mailbox-open-up' : 'mailbox-outline';
         const usps_icon = usps_packages > 0 ? 'package-variant' : 'package-variant-closed';
         const ups_icon = ups_packages > 0 ? 'package-variant' : 'package-variant-closed';
         const fedex_icon = fedex_packages > 0 ? 'package-variant' : 'package-variant-closed';
+        const amazon_icon = amazon_packages > 0 ? 'package-variant' : 'package-variant-closed';
  
         this.numberElements++;
 
@@ -165,6 +167,13 @@ class MailAndPackagesCard extends LitElement {
         <li><span class="mail-ha-icon">
                 <ha-icon icon="mdi:${fedex_icon}"></ha-icon>
             </span><a href="https://www.fedex.com/apps/fedextracking" title="Open the Fedex site" target="_blank"><span class="no-break">Fedex: ${fedex_packages}</span></a></li>
+            `
+            : ""}
+    ${amazon_packages
+    ? html`
+        <li><span class="mail-ha-icon">
+                <ha-icon icon="mdi:${amazon_icon}"></ha-icon>
+            </span><a href="https://www.amazon.com/gp/css/order-history/" title="Open the Amazon site" target="_blank"><span class="no-break">Amazon: ${amazon_packages}</span></a></li>
             `
             : ""}
     </ul>


### PR DESCRIPTION
This PR updates the missing labels for editing the card. Without this update, it is hard to determine which entity is needed.

Before:
<img width="300" alt="Screen Shot 2020-11-21 at 11 16 24 AM" src="https://user-images.githubusercontent.com/1906920/99881975-108e4400-2beb-11eb-9d65-e67327ef5405.png">
After:
<img width="300" alt="Screen Shot 2020-11-21 at 11 17 48 AM" src="https://user-images.githubusercontent.com/1906920/99881994-3a476b00-2beb-11eb-8404-6566b6b592b0.png">



This PR also adds the ability to add Amazon to the list of entities
<img width="442" alt="Screen Shot 2020-11-21 at 11 16 31 AM" src="https://user-images.githubusercontent.com/1906920/99881979-1ab04280-2beb-11eb-80d9-d755984a8f28.png">

Resolves: #8 
Partially handles #10 
